### PR TITLE
Add explicit reflection configuration for msgpack

### DIFF
--- a/package/build-native.bat
+++ b/package/build-native.bat
@@ -4,4 +4,5 @@ native-image --report-unsupported-elements-at-runtime ^
              --initialize-at-build-time ^
              --no-server ^
              -jar ../target/cq.jar ^
+             -H:ReflectionConfigurationFiles=./reflection-config.json ^
              -H:Name=../target/cq

--- a/package/build-native.sh
+++ b/package/build-native.sh
@@ -6,4 +6,5 @@ native-image --report-unsupported-elements-at-runtime \
              --initialize-at-build-time \
              --no-server \
              -jar ../target/cq.jar \
+             -H:ReflectionConfigurationFiles=./reflection-config.json \
              -H:Name=../target/cq

--- a/package/reflection-config.json
+++ b/package/reflection-config.json
@@ -1,0 +1,22 @@
+[
+ {
+  "name":"org.msgpack.template.CollectionTemplate",
+  "methods":[{"name":"<init>","parameterTypes":["org.msgpack.template.Template"] }]
+  },
+ {
+  "name":"org.msgpack.template.ListTemplate",
+  "methods":[{"name":"<init>","parameterTypes":["org.msgpack.template.Template"] }]
+  },
+ {
+  "name":"org.msgpack.template.MapTemplate",
+  "methods":[{"name":"<init>","parameterTypes":["org.msgpack.template.Template","org.msgpack.template.Template"] }]
+  },
+ {
+  "name":"org.msgpack.template.SetTemplate",
+  "methods":[{"name":"<init>","parameterTypes":["org.msgpack.template.Template"] }]
+  },
+ {
+  "name":"org.msgpack.template.builder.JavassistTemplateBuilder",
+  "methods":[{"name":"<init>","parameterTypes":["org.msgpack.template.TemplateRegistry","java.lang.ClassLoader"] }]
+  }
+ ]


### PR DESCRIPTION
I think the more proper way to do this is to add a build configuration in META-INF/native-image in the jar that native-image will consume automatically, but since this directive needs another file to consume and there isn't a build configuration already in the repo, this seemed list the most straightforward path.

Tested using `echo '{"hello": "world"}' | target/cq -o transit --transit-format-out msgpack -i json` after native build.

Resolves #13