### PR TITLE
Allow reading custom reader macros from EDN input

### DIFF
--- a/src/cq/formats.clj
+++ b/src/cq/formats.clj
@@ -34,7 +34,7 @@
 (defn ->edn-reader
   [_]
   (fn [in]
-    (edn/read (PushbackReader. (io/reader in)))))
+    (edn/read {:default tagged-literal} (PushbackReader. (io/reader in)))))
 
 (defn ->edn-writer
   [{:keys [pretty color]}]


### PR DESCRIPTION
# What

Allow cq to read custom reader macros from edn input.

# Why

I'm trying to parse an `edn` string with custom reader macros, but `cq` fails with "No reader function for tag" error.

I think cq shouldn't care about such macros, since it is used to process and format data.

# How

Add `{:default tagged-literal}` when reading edn input