### PR TITLE
Export the clojure.data.* into sci

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,14 @@ Currently supported threading operators for redirection:
 
 | Library | Namespace | Alias | Example Query |
 | ------- | --------- | ----- | ------- |
-| `tolitius/xml-in` | `xml-in.core` | `xml` | `#\| (xml/find-all . [:universe :system :solar :planet])` |
+| `tolitius/xml-in` | `xml-in.core` | `xml-in` | `#\| (xml-in/find-all . [:universe :system :solar :planet])` |
 | `medley` | `medley.core` | `m` | `(m/mak-kv (fn [k v] [v k]))` |
 | `com.rpl/specter` | `com.rpl.specter` | `s` | `(s/transform [MAP-VALS MAP-VALS] inc)` |
 | `camel-snake-kebab` | `camel-snake-kebab.core` | `csk`  | `csk/->SCREAMING_SNAKE_CASE` |
 | `clojure.instant` | `clojure.instant` | `inst`  | `inst/read-instant-timestamp` |
+| `clojure.data.csv` | `clojure.data.csv` | `csv`  | `csv/read-csv` |
+| `clojure.data.json` | `clojure.data.json` | `json`  | `json/read-str` |
+| `clojure.data.xml` | `clojure.data.xml` | `xml`  | `xml/parse-str` |
 
 
 ### Reader Macros

--- a/src/cq/core.clj
+++ b/src/cq/core.clj
@@ -7,6 +7,9 @@
 (require 'camel-snake-kebab.core)
 (require 'xml-in.core)
 (require 'clojure.instant)
+(require 'clojure.data.csv)
+(require 'clojure.data.json)
+(require 'clojure.data.xml)
 
 (def specter-bindings
   (let [publics (ns-publics (the-ns 'com.rpl.specter))]
@@ -24,7 +27,7 @@
 
 (def sci-ns-specs
   {'xml-in.core
-   {:alias 'xml}
+   {:alias 'xml-in}
    'camel-snake-kebab.core
    {:alias 'csk}
    'medley.core
@@ -32,6 +35,12 @@
    'com.rpl.specter
    {:alias 's
     :bindings-override specter-bindings}
+   'clojure.data.csv
+   {:alias 'csv}
+   'clojure.data.json
+   {:alias 'json}
+   'clojure.data.xml
+   {:alias 'xml}
    'clojure.instant
    {:alias 'inst}})
 


### PR DESCRIPTION
This provides dc, dj, and dx for csv, json, and xml. Fixes #24 

```
$ echo '{ val: "{\"answer\": 42}" }' | clojure -Mrun ':val -> (dj/read-str :key-fn keyword) :answer'
42
```