### PR TITLE
ci: adds linux arm64 artifact

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -90,7 +90,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -115,12 +115,19 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build Linux
+      - name: Build Linux x86_64
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
           ./package/build-native.sh
-          mv target/cq target/cq-native-linux
+          mv target/cq target/cq-native-linux-x86_64
+
+      - name: Build Linux ARM64
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        shell: bash
+        run: |
+          ./package/build-native.sh
+          mv target/cq target/cq-native-linux-arm64
 
       - name: Build OSX
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
This pull request updates the CI/CD workflow to add support for building on Linux ARM64 in addition to existing platforms. 

* Updated the Linux x86_64 build step to rename the output binary to `cq-native-linux-x86_64`, clarifying the architecture.

Either change yourself, or let me know whether I should change the naming :hugs: 